### PR TITLE
fix: update GitHub Pages' FQDN

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -28,7 +28,7 @@ jobs:
         uses: crazy-max/ghaction-github-pages@v1
         with:
           build_dir: dist
-          fqdn: krail.dev
+          fqdn: seankrail.dev
           target_branch: gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[krail.dev](https://krail.dev/) (and [seankrail.com](https://seankrail.com)) redirects to [seankrail.dev](https://seankrail.dev) now. Need to update the GH Pages workflow to reflect this.