### PR TITLE
fix: remove outline on focused buttons

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -137,6 +137,7 @@ img#myface-image {
 }
 
 #card a:focus {
+  outline: none;
   border: 3px solid var(--primary-color);
 }
 


### PR DESCRIPTION
Before:
<img width="234" alt="Screenshot 2023-04-15 at 2 47 22 PM" src="https://user-images.githubusercontent.com/21267343/232247991-3bb20319-d4c5-4dae-b9cb-15ab7659651b.png">

After:
<img width="227" alt="image" src="https://user-images.githubusercontent.com/21267343/232248003-67c5d90d-a00f-41eb-97e8-6434fcc14303.png">
